### PR TITLE
Update datafusion to v46

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ uwheel = { version = "0.2.1", default-features = false, features = [
   "all",
 ] }
 datafusion-uwheel = { path = "datafusion-uwheel", version = "40.0.0" }
-datafusion = "43.0.0"
+datafusion = "46.0.0"
 chrono = "0.4.38"
 bitpacking = "0.9.2"
 tokio = "1.38.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["benchmarks/nyc_taxi_bench", "datafusion-uwheel", "examples/*"]
 
 [workspace.package]
-version = "40.0.0"
+version = "46.0.0"
 edition = "2021"
 authors = ["Max Meldrum <max@meldrum.se>"]
 license = "Apache-2.0"

--- a/benchmarks/nyc_taxi_bench/Cargo.toml
+++ b/benchmarks/nyc_taxi_bench/Cargo.toml
@@ -8,7 +8,7 @@ debug = []
 
 [dependencies]
 datafusion-uwheel = { path = "../../datafusion-uwheel" }
-datafusion = "43.0.0"
+datafusion = "46.0.0"
 mimalloc = { version = "*", default-features = false, optional = true }
 tokio = { version = "1", features = ["full"] }
 chrono = "0.4.38"


### PR DESCRIPTION
THis PR upgrades the project to support datafusion v46. 

A question, should we bump the version number? And what should I bump it to? 
from version = "40.0.0" ==> "41.0.0" ? 
 